### PR TITLE
Command URL Fix

### DIFF
--- a/icinga/api.py
+++ b/icinga/api.py
@@ -91,7 +91,7 @@ class API:
         params["authkey"] = self.api_app_id
         args = "/cmd"
         for param in params:
-            args = args + "/%s=%s" % (param, params[param])
+            args = args + "%s=%s" % (param, params[param])
 
         url = self.api_base_url + urllib.quote(args.replace('\'', '"'))
         log.debug("CMD URL: %s" % self.api_base_url + args.replace('\'', '"'))


### PR DESCRIPTION
Thanks for this tool, it is exactly what I needed. I noticed my commands where failing because in the "search" functions no slash is added to the base URL, but in the command section it was. This resulted in an invalid url  of "http://base//cmd/.....". This just removes the slash when creating the command, so the icl.cfg file needs to have a trailing slash.

I suppose testing for the trailing slash on the base URL and adding it during the initialization process might be a good addition to this but this fixed what I needed to make both the search and cmd pieces work. 
